### PR TITLE
Add instrumented leaderboard repos

### DIFF
--- a/src/main/java/com/yebyrkc/LeaderboardREST/config/RepositoryConfiguration.java
+++ b/src/main/java/com/yebyrkc/LeaderboardREST/config/RepositoryConfiguration.java
@@ -1,0 +1,29 @@
+package com.yebyrkc.LeaderboardREST.config;
+
+import com.yebyrkc.LeaderboardREST.repository.*;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+
+/**
+ * Provides decorated repository beans with instrumentation applied.
+ */
+@Configuration
+public class RepositoryConfiguration {
+
+    @Bean("javaRepo")
+    public LeaderboardRepository javaRepository(MeterRegistry registry) {
+        return new InstrumentedLeaderboardRepository(new InMemoryLeaderboardRepository(), registry, "java");
+    }
+
+    @Bean("caffeineRepo")
+    public LeaderboardRepository caffeineRepository(MeterRegistry registry) {
+        return new InstrumentedLeaderboardRepository(new CaffeineLeaderboardRepository(), registry, "caffeine");
+    }
+
+    @Bean("redisRepo")
+    public LeaderboardRepository redisRepository(RedisTemplate<String, String> redisTemplate, MeterRegistry registry) {
+        return new InstrumentedLeaderboardRepository(new RedisLeaderboardRepository(redisTemplate, registry), registry, "redis");
+    }
+}

--- a/src/main/java/com/yebyrkc/LeaderboardREST/repository/InstrumentedLeaderboardRepository.java
+++ b/src/main/java/com/yebyrkc/LeaderboardREST/repository/InstrumentedLeaderboardRepository.java
@@ -1,0 +1,129 @@
+package com.yebyrkc.LeaderboardREST.repository;
+
+import com.yebyrkc.LeaderboardREST.model.LeaderboardEntry;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+import java.util.List;
+
+/**
+ * Decorates a {@link LeaderboardRepository} with Micrometer metrics.
+ */
+public class InstrumentedLeaderboardRepository implements LeaderboardRepository {
+
+    private final LeaderboardRepository delegate;
+    private final MeterRegistry meterRegistry;
+    private final Timer incrementScoreTimer;
+    private final Timer getTopPlayersTimer;
+    private final Timer getPlayerTimer;
+    private final Timer getPlayerRankTimer;
+    private final Timer addPlayerEntryTimer;
+    private final Timer addPlayerEntriesTimer;
+    private final Timer deletePlayerEntryTimer;
+    private final Timer deleteAllPlayerEntriesTimer;
+    private final Counter playerHitCounter;
+    private final Counter playerMissCounter;
+
+    public InstrumentedLeaderboardRepository(LeaderboardRepository delegate, MeterRegistry registry, String backendType) {
+        this.delegate = delegate;
+        this.meterRegistry = registry;
+        this.incrementScoreTimer = registry.timer("leaderboard.incrementScore", "backend", backendType);
+        this.getTopPlayersTimer = registry.timer("leaderboard.getTopPlayers", "backend", backendType);
+        this.getPlayerTimer = registry.timer("leaderboard.getPlayer", "backend", backendType);
+        this.getPlayerRankTimer = registry.timer("leaderboard.getPlayerRank", "backend", backendType);
+        this.addPlayerEntryTimer = registry.timer("leaderboard.addPlayerEntry", "backend", backendType);
+        this.addPlayerEntriesTimer = registry.timer("leaderboard.addPlayerEntries", "backend", backendType);
+        this.deletePlayerEntryTimer = registry.timer("leaderboard.deletePlayerEntry", "backend", backendType);
+        this.deleteAllPlayerEntriesTimer = registry.timer("leaderboard.deleteAllPlayerEntries", "backend", backendType);
+        this.playerHitCounter = registry.counter("leaderboard.getPlayer.hit", "backend", backendType);
+        this.playerMissCounter = registry.counter("leaderboard.getPlayer.miss", "backend", backendType);
+    }
+
+    @Override
+    public double incrementScore(String playerId, double increment) {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        try {
+            return delegate.incrementScore(playerId, increment);
+        } finally {
+            sample.stop(incrementScoreTimer);
+        }
+    }
+
+    @Override
+    public List<LeaderboardEntry> getTopPlayers(int n) {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        try {
+            return delegate.getTopPlayers(n);
+        } finally {
+            sample.stop(getTopPlayersTimer);
+        }
+    }
+
+    @Override
+    public LeaderboardEntry getPlayer(String playerId) {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        LeaderboardEntry entry = null;
+        try {
+            entry = delegate.getPlayer(playerId);
+            return entry;
+        } finally {
+            sample.stop(getPlayerTimer);
+            if (entry != null) {
+                playerHitCounter.increment();
+            } else {
+                playerMissCounter.increment();
+            }
+        }
+    }
+
+    @Override
+    public long getPlayerRank(String playerId) {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        try {
+            return delegate.getPlayerRank(playerId);
+        } finally {
+            sample.stop(getPlayerRankTimer);
+        }
+    }
+
+    @Override
+    public void addPlayerEntry(String playerId, String username, int level, double initialScore) {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        try {
+            delegate.addPlayerEntry(playerId, username, level, initialScore);
+        } finally {
+            sample.stop(addPlayerEntryTimer);
+        }
+    }
+
+    @Override
+    public void addPlayerEntries(List<LeaderboardEntry> entries) {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        try {
+            delegate.addPlayerEntries(entries);
+        } finally {
+            sample.stop(addPlayerEntriesTimer);
+        }
+    }
+
+    @Override
+    public void deletePlayerEntry(String playerId) {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        try {
+            delegate.deletePlayerEntry(playerId);
+        } finally {
+            sample.stop(deletePlayerEntryTimer);
+        }
+    }
+
+    @Override
+    public void deleteAllPlayerEntries() {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        try {
+            delegate.deleteAllPlayerEntries();
+        } finally {
+            sample.stop(deleteAllPlayerEntriesTimer);
+        }
+    }
+}

--- a/src/main/java/com/yebyrkc/LeaderboardREST/repository/LeaderboardRepositoryRouter.java
+++ b/src/main/java/com/yebyrkc/LeaderboardREST/repository/LeaderboardRepositoryRouter.java
@@ -1,0 +1,38 @@
+package com.yebyrkc.LeaderboardREST.repository;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Simple router to resolve repositories by type.
+ */
+@Component
+public class LeaderboardRepositoryRouter {
+
+    private final LeaderboardRepository javaRepo;
+    private final LeaderboardRepository caffeineRepo;
+    private final LeaderboardRepository redisRepo;
+
+    public LeaderboardRepositoryRouter(@Qualifier("javaRepo") LeaderboardRepository javaRepo,
+                                        @Qualifier("caffeineRepo") LeaderboardRepository caffeineRepo,
+                                        @Qualifier("redisRepo") LeaderboardRepository redisRepo) {
+        this.javaRepo = javaRepo;
+        this.caffeineRepo = caffeineRepo;
+        this.redisRepo = redisRepo;
+    }
+
+    public LeaderboardRepository resolve(String type) {
+        return switch (type.toLowerCase()) {
+            case "java" -> javaRepo;
+            case "caffeine" -> caffeineRepo;
+            case "redis" -> redisRepo;
+            default -> throw new IllegalArgumentException("Unknown repository type: " + type);
+        };
+    }
+
+    public List<LeaderboardRepository> getAll() {
+        return List.of(javaRepo, caffeineRepo, redisRepo);
+    }
+}

--- a/src/main/java/com/yebyrkc/LeaderboardREST/service/Leaderboard/LeaderboardService.java
+++ b/src/main/java/com/yebyrkc/LeaderboardREST/service/Leaderboard/LeaderboardService.java
@@ -2,6 +2,7 @@ package com.yebyrkc.LeaderboardREST.service.Leaderboard;
 
 import com.yebyrkc.LeaderboardREST.model.LeaderboardEntry;
 import com.yebyrkc.LeaderboardREST.repository.LeaderboardRepository;
+import com.yebyrkc.LeaderboardREST.repository.LeaderboardRepositoryRouter;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -9,41 +10,51 @@ import java.util.List;
 @Service
 public class LeaderboardService {
 
-    private final LeaderboardRepository repository;
+    private final LeaderboardRepositoryRouter router;
+    private final LeaderboardRepository defaultRepository;
 
-    public LeaderboardService(LeaderboardRepository repository) {
-        this.repository = repository;
+    public LeaderboardService(LeaderboardRepositoryRouter router) {
+        this.router = router;
+        this.defaultRepository = router.resolve("java");
     }
 
     public double incrementScore(String playerId, double increment) {
-        return repository.incrementScore(playerId, increment);
+        return defaultRepository.incrementScore(playerId, increment);
     }
 
     public List<LeaderboardEntry> getTopPlayers(int n) {
-        return repository.getTopPlayers(n);
+        return defaultRepository.getTopPlayers(n);
     }
 
     public LeaderboardEntry getPlayer(String playerId) {
-        return repository.getPlayer(playerId);
+        return defaultRepository.getPlayer(playerId);
     }
 
     public long getPlayerRank(String playerId) {
-        return repository.getPlayerRank(playerId);
+        return defaultRepository.getPlayerRank(playerId);
     }
 
     public void addPlayerEntry(String playerId, String username, int level, double initialScore) {
-        repository.addPlayerEntry(playerId, username, level, initialScore);
+        defaultRepository.addPlayerEntry(playerId, username, level, initialScore);
     }
 
     public void addPlayerEntries(List<LeaderboardEntry> entries) {
-        repository.addPlayerEntries(entries);
+        defaultRepository.addPlayerEntries(entries);
     }
 
     public void deletePlayerEntry(String playerId) {
-        repository.deletePlayerEntry(playerId);
+        defaultRepository.deletePlayerEntry(playerId);
     }
 
     public void deleteAllPlayerEntries() {
-        repository.deleteAllPlayerEntries();
+        defaultRepository.deleteAllPlayerEntries();
+    }
+
+    public LeaderboardRepository resolve(String type) {
+        return router.resolve(type);
+    }
+
+    public void addPlayerEntriesToAll(List<LeaderboardEntry> entries) {
+        router.getAll().parallelStream().forEach(r -> r.addPlayerEntries(entries));
     }
 }

--- a/src/main/java/com/yebyrkc/LeaderboardREST/service/PlayerGenerator/PlayerGenerator.java
+++ b/src/main/java/com/yebyrkc/LeaderboardREST/service/PlayerGenerator/PlayerGenerator.java
@@ -108,6 +108,6 @@ public class PlayerGenerator {
         }
         logger.debug("Created {}  players", count);
 
-        leaderboardService.addPlayerEntries(entries);  // single call
+        leaderboardService.addPlayerEntriesToAll(entries);
     }
 }


### PR DESCRIPTION
## Summary
- add `InstrumentedLeaderboardRepository` with timers and hit/miss counters
- expose decorated repository beans in `RepositoryConfiguration`
- route repository instances via `LeaderboardRepositoryRouter`
- update `LeaderboardService` to use router and allow parallel inserts
- generate players in all backends

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6864e3da84e88323894eef1129d3ee3c